### PR TITLE
Tekst voor offerReadySubject aangepast.

### DIFF
--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -550,7 +550,7 @@ reproductionMail.pendingSubjectReadingRoomMessage=A customer has requested a new
   and is waiting for an offer from the Reading Room.
 reproductionMail.offerReadySubject=Confirmation of reproduction - Your offer is ready
 reproductionMail.offerReadyMessage=With this e-mail we confirm your \
-  reproduction request. You can complete your order on the following link:
+  reproduction request. You can complete your order on the following link. Please note that you can only click on the link once:
 reproductionMail.offerReminderSubject=Reminder of reproduction
 reproductionMail.offerReminderMessage=Recently we have sent you a quote, in response to a request for reproductions. \
 Until now we haven't received your payment. By following the link below, you can complete your payment. \

--- a/src/main/resources/messages_nl.properties
+++ b/src/main/resources/messages_nl.properties
@@ -545,7 +545,7 @@ reproductionMail.pendingSubjectReadingRoomMessage=Een klant heeft een nieuwe rep
   ingediend en wacht nu op een offerte van de studiezaal.
 reproductionMail.offerReadySubject=Bevestiging van reproductie - Uw offerte is aangemaakt
 reproductionMail.offerReadyMessage=Met deze e-mail bevestigen we uw reproductieaanvraag. \
-  Door te klikken op de volgende link kunt u uw bestelling voltooien:
+  Door te klikken op de volgende link kunt u uw bestelling voltooien. Houd er rekening mee dat u slechts één keer op de link kunt klikken:
 reproductionMail.offerReminderSubject=Herinnering van reproductie
 reproductionMail.offerReminderMessage=Onlangs hebben we u een offerte gedaan naar aanleiding van een reproductieaanvraag. \
 Tot nu toe hebben we geen betaling ontvangen. Door te klikken op onderstaande link kunt u uw bestelling voltooien. \


### PR DESCRIPTION
Omdat na de klik op de link de mollie order aldaar wordt aangemaakt loopt de teller.
Links kunnen dan expireren als gebruikers wel klikken maar niet meteen de trasnsactie uitvoeren.